### PR TITLE
Improve SiteHeader link security and UX

### DIFF
--- a/apps/web/components/layout/site-header.tsx
+++ b/apps/web/components/layout/site-header.tsx
@@ -12,12 +12,12 @@ const SiteHeader = () => {
         </span>
         <div className="flex items-center gap-2">
           <Button variant="ghost" size="icon" className="rounded-none">
-            <Link href="https://l.oss.now/gh/" target="_blank">
+            <Link href="https://l.oss.now/gh/" target="_blank" rel="noopener noreferrer">
               <Icons.github className="size-5 fill-white" />
             </Link>
           </Button>
           <Button variant="ghost" size="icon" className="rounded-none">
-            <Link href="https://l.oss.now/x/" target="_blank">
+            <Link href="https://l.oss.now/x/" target="_blank" rel="noopener noreferrer">
               <Icons.twitter className="size-5 fill-white" />
             </Link>
           </Button>

--- a/apps/web/components/layout/site-header.tsx
+++ b/apps/web/components/layout/site-header.tsx
@@ -12,12 +12,12 @@ const SiteHeader = () => {
         </span>
         <div className="flex items-center gap-2">
           <Button variant="ghost" size="icon" className="rounded-none">
-            <Link href="https://l.oss.now/gh/">
+            <Link href="https://l.oss.now/gh/" target="_blank">
               <Icons.github className="size-5 fill-white" />
             </Link>
           </Button>
           <Button variant="ghost" size="icon" className="rounded-none">
-            <Link href="https://l.oss.now/x/">
+            <Link href="https://l.oss.now/x/" target="_blank">
               <Icons.twitter className="size-5 fill-white" />
             </Link>
           </Button>


### PR DESCRIPTION
## What Changed

- Updated GitHub and Twitter icon links in the `SiteHeader` component to include:
  - `target="_blank"` attribute to open links in new tabs
  - `rel="noopener noreferrer"` attribute to prevent security vulnerabilities

## Why This Change Matters

This change improves both security and user experience:

1. **Security Enhancement**: Adding `rel="noopener noreferrer"` mitigates the risk of potential vulnerabilities associated with `window.opener` that could be exploited when users click external links.

2. **Better User Experience**: Opening external links in new tabs (`target="_blank"`) ensures users don't lose their place in our application when visiting external resources.

## Notes for Reviewers

- No breaking changes
- This follows web security best practices for external links
- Implementation is focused on the `SiteHeader` component only