### PR TITLE
Fix social button redirection with `asChild` prop in SiteHeader

### DIFF
--- a/apps/web/components/layout/site-header.tsx
+++ b/apps/web/components/layout/site-header.tsx
@@ -11,12 +11,12 @@ const SiteHeader = () => {
           <span className="text-2xl font-medium">oss.now</span>
         </span>
         <div className="flex items-center gap-2">
-          <Button variant="ghost" size="icon" className="rounded-none">
+          <Button variant="ghost" size="icon" className="rounded-none" asChild>
             <Link href="https://l.oss.now/gh/" target="_blank" rel="noopener noreferrer">
               <Icons.github className="size-5 fill-white" />
             </Link>
           </Button>
-          <Button variant="ghost" size="icon" className="rounded-none">
+          <Button variant="ghost" size="icon" className="rounded-none" asChild>
             <Link href="https://l.oss.now/x/" target="_blank" rel="noopener noreferrer">
               <Icons.twitter className="size-5 fill-white" />
             </Link>


### PR DESCRIPTION
## What Changed
- Added the `asChild` prop to `Button` components that wrap `Link` elements in the `SiteHeader` component

## Why This Change Matters
This PR fixes a redirection bug where:
- Users were unable to be redirected when clicking social buttons
- Only the icon within the link was clickable, not the entire button area
- Using `asChild` prop properly delegates the button's functionality to the `Link` component while maintaining button styling

## Technical Details
- The `asChild` prop allows the `Link` component to inherit all the button's properties
- This ensures the entire button area is clickable and properly redirects users
- Improves user experience by making social links work as expected

## Notes for Reviewers
- No breaking changes
- Simple fix with significant UX improvement
- Validates that social links work correctly after the change

https://share.cleanshot.com/Wx2bPM6M